### PR TITLE
Display question attatchments edit quiz

### DIFF
--- a/mentapp/models.py
+++ b/mentapp/models.py
@@ -130,13 +130,11 @@ class Question_Attachment(models.Model):
     question = models.ForeignKey(Question_Loc, on_delete=models.CASCADE)
     lang_code = models.CharField(max_length=5, default="ENG")
     dialect_code = models.CharField(max_length=5, default="US")
-    filename = models.FileField(
-        upload_to="question_attachments/",
-    )
-    blob_key = models.ForeignKey(Blob, on_delete=models.CASCADE, null=True)
+    filename = models.CharField(max_length=255)
+    blob = models.ForeignKey(Blob, on_delete=models.CASCADE, null=True)
 
     class Meta:
-        unique_together = ("question", "lang_code", "dialect_code")
+        unique_together = ("question", "filename", "lang_code", "dialect_code")
         indexes = [
             models.Index(
                 fields=["question", "lang_code", "dialect_code"],

--- a/mentapp/urls.py
+++ b/mentapp/urls.py
@@ -2,10 +2,15 @@ from django.urls import path
 
 from . import views
 
+from django.urls import path
+
+
+
 
 
 urlpatterns = [
 
     path("<int:volume_number>/", views.volume_chapter, name="volume_chapter"),
-    path("", views.volumes, name="volumes"),
-]
+    path("", views.volumes, name="volumes")
+] 
+

--- a/mentoris/settings.py
+++ b/mentoris/settings.py
@@ -76,6 +76,14 @@ WSGI_APPLICATION = "mentoris.wsgi.application"
 # https://docs.djangoproject.com/en/4.1/ref/settings/#databases
 
 
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    }
+}
+
+
 
 STORAGES = {
     "default": {
@@ -124,6 +132,10 @@ USE_TZ = True
 STATIC_URL = "static/"
 STATIC_ROOT = "static"
 STATICFILES_DIRS = ["mentoris/static"]
+
+
+MEDIA_URL = "/media/"
+MEDIA_ROOT = BASE_DIR / "media"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field

--- a/mentoris/static/css/quiz_styles.css
+++ b/mentoris/static/css/quiz_styles.css
@@ -1,7 +1,7 @@
 li {
     font-size: .9em;
+    padding: 0px;
 }
-
 
 .form_label {
     display: inline-block;
@@ -41,7 +41,7 @@ button {
     border-radius: 25px;
     margin: 5px;
     width: 8em;
-    height: 2em;
+    min-height: 2em;
 }
 
 button:hover {

--- a/mentoris/static/scripts/toggle_attachments_visible.js
+++ b/mentoris/static/scripts/toggle_attachments_visible.js
@@ -1,0 +1,33 @@
+/*
+* A method to toggle the visibility of attachments
+* list_element_id   The container that the attachments and button are in
+* button   The reference to the button in the attachments container
+* attachment_class_name   The name of the class that contains the attachments to show or hide
+*
+* Assumes that the button has the class visible_state to indicate it is currently visible
+*/
+function toggle_attachments_visible(list_element_id, button, attachment_class_name){
+    var list_element = document.getElementById(list_element_id);
+    var list = list_element.children;
+    var index = -1;
+
+    for(var i = 0; i < list.length; ++i){
+        if(list[i].contains(button)){
+            index = i;
+        }
+    }
+    if(index != -1){
+        if($(button).hasClass("visible_state")){
+            $(button).text("Show Attachments");
+            $(button).addClass("invisible_state");
+            $(list[index].getElementsByClassName(attachment_class_name)[0]).hide();
+            $(button).removeClass("visible_state");
+
+        } else {
+            $(button).text("Hide Attachments");
+            $(button).addClass("visible_state");
+            $(list[index].getElementsByClassName(attachment_class_name)[0]).show();
+            $(button).removeClass("invisible_state");
+        }
+    }
+}

--- a/mentoris/templates/mentapp/edit_quiz.html
+++ b/mentoris/templates/mentapp/edit_quiz.html
@@ -62,7 +62,7 @@
         <div id = "quiz_content" class = "bordered" background="red">
             <ul id = "quiz_questions_list" style="list-style-type:none;">
                 {% for question_Loc_and_quiz in questions_Loc_and_quiz %}
-                    <li>
+                    <li id = "{{question_Loc_and_quiz.0.question.question_id}}">
                         <div class="bordered">
 
                                 <p class="bold_font question_support_label" >

--- a/mentoris/templates/mentapp/edit_quiz.html
+++ b/mentoris/templates/mentapp/edit_quiz.html
@@ -16,6 +16,7 @@
         <link rel="stylesheet" href="{% static "/css/quiz_styles.css"%}">
 
         <script src="https://cdn.jsdelivr.net/npm/latex.js/dist/latex.js"></script>
+        <script src= "{% static "/scripts/toggle_attachments_visible.js" %}"></script>
         <script>
             customElements.define("latex-js", latexjs.LaTeXJSComponent);
         </script>
@@ -31,10 +32,11 @@
                 text-align: center;
                 border: 2px solid Black;
                 border-radius: 25px;
-                margin: 5px;
-                width: 8em;
+                margin: 0px;
+                width: 100%;
                 height: 2em;
-                vertical-align: middle;
+                background-color:  var(--KontinuaBlue);
+                
             }
 
             #quiz_content {
@@ -60,9 +62,12 @@
         <div id = "quiz_content" class = "bordered" background="red">
             <ul id = "quiz_questions_list" style="list-style-type:none;">
                 {% for question_Loc_and_quiz in questions_Loc_and_quiz %}
-                <li id = "{{question_Loc_and_quiz.0.question.question_id}}">
-                    <div class = "bordered">
-                        <div>
+                    <li>
+                        <div class="bordered">
+
+                                <p class="bold_font question_support_label" >
+                                    Question
+                                </p>
                             <div style="float: left;">
                                 <p class = "small_margin"> 
                                     <span class="bold_font">Ordering: </span>
@@ -113,16 +118,21 @@
                             </div>
                             <div style="clear: both;">
                                 <latex-js>{{question_Loc_and_quiz.0.question_latex}}</latex-js>
-                            </div>
-                            <div style="float: right;">
-                                <p class="bold_font question_support_label" 
-                                    style="background-color:  var(--KontinuaBlue);">
-                                    Question</p>
+
+                                {% if question_Loc_and_quiz.2 %}
+                                <div style="float: right">
+                                    <button class="attachments_button invisible_state bold_font">Show Attatchments</button>
+                                </div>
+                                <div class = "bordered attachments" style = "clear:both; display: none;">
+                                    {% for image in question_Loc_and_quiz.2%}
+                                        <img src = "{{image.url}}" width="200" style = "position:relative; left: 25%">
+                                    {% endfor %}
+                                </div>
+                                {% endif %}
                             </div>
                         </div>
-                    </div>
                 </li>
-            {% endfor %}
+                {% endfor %}
             </ul>
         </div>
 
@@ -278,6 +288,11 @@
                         }
                     }
                     list_element.removeChild(list[index]);
+                });
+
+                // Function to toggle attachment visibility
+                $('.attachments_button').on('click', function(event){
+                    toggle_attachments_visible("quiz_questions_list", $(this)[0], "attachments");
                 });
                 
                 // Function to handle increasing order

--- a/mentoris/templates/mentapp/edit_quiz_add_question.html
+++ b/mentoris/templates/mentapp/edit_quiz_add_question.html
@@ -16,6 +16,7 @@
         <link rel="stylesheet" href="{% static "/css/quiz_styles.css"%}">
 
         <script src="https://cdn.jsdelivr.net/npm/latex.js/dist/latex.js"></script>
+        <script src= "{% static "/scripts/toggle_attachments_visible.js" %}"></script>
         <script>
             customElements.define("latex-js", latexjs.LaTeXJSComponent);
         </script>
@@ -185,11 +186,12 @@
                         for(const i in data){
                             var list_item = document.createElement("li");
                             list_item.id = data[i]["question_id"];
-                        
+                            
+                            // border for each question
                             var border_wrapper = document.createElement("div");
                             $(border_wrapper).addClass("bordered");
                         
-                            
+                            // wrapper containing question meta data
                             var question_wrapper = document.createElement("div");
                             question_wrapper.style.float = "left";
                             question_wrapper.appendChild(make_attribute_label("Difficulty: ", "conceptual_difficulty", data[i]["conceptual_difficulty"]));
@@ -200,29 +202,64 @@
                             question_wrapper.appendChild(make_attribute_label("Time (minutes): ", "time_required_mins", data[i]["time_required_mins"]));
                             border_wrapper.appendChild(question_wrapper);
 
+                            // wrapper for add button
                             var button_wrapper = document.createElement("div");
                             button_wrapper.style.float = "right";
 
+                            // add button
                             var add_button = document.createElement("button");
                             add_button.innerHTML = "Add";
                             add_button.addEventListener('click', function(event){
                                 toggle_add(event.target);
                             });
-
                             $(add_button).addClass("add_question_button");
                             $(add_button).addClass("add_question_add_state");
                             $(add_button).addClass("bold_font");
                             button_wrapper.appendChild(add_button);
                             border_wrapper.appendChild(button_wrapper);
 
+                            // latex wrapper
                             var latex_wrapper = document.createElement("div");
                             latex_wrapper.style.clear = "both";
-
+                            
+                            // latex display
                             var latex = document.createElement("latex-js");
                             latex.innerHTML=  data[i]["question_latex"] 
                             latex_wrapper.appendChild(latex);
                             border_wrapper.appendChild(latex_wrapper);
 
+                            // show attachments and toggle if at least 1 attachment exists 
+                            if(data[i]["attachment_urls"].length > 0){
+                                var attachment_button_wrapper = document.createElement("div");
+                                attachment_button_wrapper.style.float = "right";
+                                attachment_button = document.createElement("button");
+                                attachment_button.innerHTML = "Show Attachments";
+                                $(attachment_button).addClass("bold_font");
+                                attachment_button_wrapper.appendChild(attachment_button);
+
+                                attachment_button.addEventListener('click', function(event){
+                                    toggle_attachments_visible("questions_list", event.target, "attachments");
+                                });
+
+                                border_wrapper.appendChild(attachment_button_wrapper);
+                            
+                                var attachment_wrapper = document.createElement("div");
+                                $(attachment_wrapper).addClass("bordered")
+                                $(attachment_wrapper).addClass("attachments")
+                                $(attachment_wrapper).addClass("invisible_state")
+                                attachment_wrapper.style.clear = "both";
+                                attachment_wrapper.style.display = "none";
+                                border_wrapper.appendChild(attachment_wrapper);
+
+                                for(const j in data[i]["attachment_urls"]){
+                                    var image = document.createElement("img");
+                                    image.src = data[i]["attachment_urls"][j];
+                                    image.width = "200";
+                                    image.style.position = "relative";
+                                    image.style.left = "25%";
+                                    attachment_wrapper.appendChild(image);
+                                }
+                            }
                             list_item.appendChild(border_wrapper);
                             document.getElementById("questions_list").appendChild(list_item);
                         }

--- a/mentoris/urls.py
+++ b/mentoris/urls.py
@@ -17,6 +17,8 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from . import views
+from django.conf.urls.static import static
+from django.conf import settings
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -38,4 +40,4 @@ urlpatterns = [
     path("<str:page>/footer.html/", views.footer, name="footer"),
     path("download_pdf/<int:blob_key>/", views.download_pdf, name='download_pdf'),
     path("upload_pdf/<path:pdf_path>/", views.upload_pdf, name='upload_pdf'),
-]
+]+ static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Changes:
edit_quiz_add_question.html: Display images
edit_quiz.html: Display images
views.py: Serve images to respective templates
settings.py: set MEDIA_URL and MEDIA_ROOT to allow user generated images to be stored and shared
urls.py: added routing for user generated images

scripts: added a scripts folder for scripts that can be reused across the project and added 1 script that is used by edit_quiz_add_question.html and edit_quiz.html