### PR TITLE
Fixed the Default Routing

### DIFF
--- a/mentoris/urls.py
+++ b/mentoris/urls.py
@@ -24,6 +24,7 @@ from django.conf import settings
 urlpatterns = [
     re_path(r".*/header.html/", views.header, name="header"),
     re_path(r".*/footer.html/", views.footer, name="footer"),
+    path("", views.default, name="default"),
     path("admin/", admin.site.urls),
     path("latex/", views.latex, name="latex_question"),
     path("login/", views.customLogin, name="login"),
@@ -38,13 +39,29 @@ urlpatterns = [
     path("main/<int:volume_id>/", views.main, name="main_vol_chap"),
     path("main/<int:volume_id>/<chapter_id>/", views.chapter, name="chapter"),
     path("main/<int:volume_id>/<chapter_id>/<int:quiz_id>", views.quiz, name="quiz"),
-    path("main/<int:volume_id>/<chapter_id>/<int:quiz_id>/maker_view", views.quiz_maker_view, name="quiz_maker_view"),
+    path(
+        "main/<int:volume_id>/<chapter_id>/<int:quiz_id>/maker_view",
+        views.quiz_maker_view,
+        name="quiz_maker_view",
+    ),
     path("edit_quiz/<int:quiz_id>", views.edit_quiz, name="edit_quiz"),
-    path("edit_quiz_add_question/<int:quiz_id>", views.edit_quiz_add_question, name="edit_quiz_add_question"),
-    path("edit_quiz_add_support/<int:quiz_id>", views.edit_quiz_add_support, name="edit_quiz_add_support"),
+    path(
+        "edit_quiz_add_question/<int:quiz_id>",
+        views.edit_quiz_add_question,
+        name="edit_quiz_add_question",
+    ),
+    path(
+        "edit_quiz_add_support/<int:quiz_id>",
+        views.edit_quiz_add_support,
+        name="edit_quiz_add_support",
+    ),
     path("download_pdf/<int:quiz_id>/", views.download_pdf, name="download_pdf"),
     path("create_support/", views.create_support, name="create_support"),
-    path("quiz/create/<int:volume_id>/<chapter_id>", views.create_quiz, name="create_quiz"),
+    path(
+        "quiz/create/<int:volume_id>/<chapter_id>",
+        views.create_quiz,
+        name="create_quiz",
+    ),
     path("delete_quiz/<int:quiz_id>/", views.delete_quiz, name="delete_quiz"),
     path("question_approval/", views.question_approval, name="question_approval"),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/mentoris/views.py
+++ b/mentoris/views.py
@@ -39,41 +39,58 @@ from mentoris.latex_to_pdf import latex_to_pdf
 
 from functools import wraps
 
+
 def mentor_req(view_func):
     @wraps(view_func)
     def _wrapped_view(request, *args, **kwargs):
-        #Checking that there is a logged in user else return to the login page
+        # Checking that there is a logged in user else return to the login page
         if not request.user.is_authenticated:
             return render(request, "mentapp/login.html")
-        #Checking that user is mentor (verified) or higher else returning an error
-        if not (request.user.is_quizmaker or request.user.is_admin or request.user.is_verified):
-            return HttpResponseForbidden("Forbidden: Must be mentor or quizmaker to access add questions page.")
+        # Checking that user is mentor (verified) or higher else returning an error
+        if not (
+            request.user.is_quizmaker
+            or request.user.is_admin
+            or request.user.is_verified
+        ):
+            return HttpResponseForbidden(
+                "Forbidden: Must be mentor or quizmaker to access add questions page."
+            )
         return view_func(request, *args, **kwargs)
+
     return _wrapped_view
+
 
 def quizmaker_req(view_func):
     @wraps(view_func)
     def _wrapped_view(request, *args, **kwargs):
-        #Checking that there is a logged in user else return to the login page
+        # Checking that there is a logged in user else return to the login page
         if not request.user.is_authenticated:
             return render(request, "mentapp/login.html")
-        #Checking user is quiz maker or higher else returning forbidden HTTP page.
+        # Checking user is quiz maker or higher else returning forbidden HTTP page.
         if not (request.user.is_quizmaker or request.user.is_admin):
-            return HttpResponseForbidden("Forbidden: Must be quizmaker or admin to access edit quiz.")
+            return HttpResponseForbidden(
+                "Forbidden: Must be quizmaker or admin to access edit quiz."
+            )
         return view_func(request, *args, **kwargs)
+
     return _wrapped_view
+
 
 def admin_req(view_func):
     @wraps(view_func)
     def _wrapped_view(request, *args, **kwargs):
-        #Checking that there is a logged in user else return to the login page
+        # Checking that there is a logged in user else return to the login page
         if not request.user.is_authenticated:
-            return redirect('admin:login')
-        #Must be admin!
+            return redirect("admin:login")
+        # Must be admin!
         if not request.user.is_admin:
-            return HttpResponseForbidden("Forbidden: Must be admin to access edit quiz.")
+            return HttpResponseForbidden(
+                "Forbidden: Must be admin to access edit quiz."
+            )
         return view_func(request, *args, **kwargs)
+
     return _wrapped_view
+
 
 @mentor_req
 def latex(request):
@@ -206,6 +223,15 @@ def latex(request):
         )
 
 
+def default(request):
+    if not request.user:
+        return redirect(f"../login")
+    elif not request.user.is_verified:
+        return redirect(f"../profile/{request.user.user_id}")
+    else:
+        return redirect(f"../main")
+
+
 def sign_up(request):
     if request.method == "POST":
         # Add to User table
@@ -308,6 +334,7 @@ def customLogin(request):
     else:
         return render(request, "mentapp/login.html")
 
+
 @mentor_req
 def main(request, volume_id=1):
     template = loader.get_template("mentapp/main.html")
@@ -360,6 +387,7 @@ def chapter(request, volume_id, chapter_id):
             "quizzes": quizzes,
         },
     )
+
 
 @mentor_req
 def quiz(request, volume_id, chapter_id, quiz_id):
@@ -439,6 +467,7 @@ def quiz(request, volume_id, chapter_id, quiz_id):
             },
         )
 
+
 @quizmaker_req
 def quiz_maker_view(request, volume_id, chapter_id, quiz_id):
     volume_id = get_object_or_404(Volume, volume_id=volume_id)
@@ -501,6 +530,7 @@ def quiz_maker_view(request, volume_id, chapter_id, quiz_id):
             },
         )
 
+
 @quizmaker_req
 def question_approval(request):
     if request.method == "POST":
@@ -538,6 +568,7 @@ def question_approval(request):
         {"question": question_info},
     )
 
+
 @admin_req
 def promotion(request):
     if request.method == "POST":
@@ -568,6 +599,7 @@ def promotion(request):
                 "quiz_makers": grab_users(True, True, False, True, True),
             },
         )
+
 
 @admin_req
 def user_directory(request):


### PR DESCRIPTION
The default page: (http://127.0.0.1:8000/) will redirect the user to either the login, profile, or main page depending if they are logged in or a mentor+. 

It no longer returns the error: Page Not Found