### PR TITLE
Create Quiz Bug

### DIFF
--- a/mentoris/views.py
+++ b/mentoris/views.py
@@ -1069,7 +1069,7 @@ def upload_pdf(request, pdf_path):
     except Exception as e:
         return JsonResponse({"status": "error", "message": str(e)})
 
-
+@quizmaker_req
 def create_quiz(request, volume_id, chapter_id):
     if request.method == "POST":
         # Create a new Quiz instance


### PR DESCRIPTION
Fixed bug just needed to protect create API instead of edit API. When edit was clicked was running create API before checking the edit perms could have protected button, but easier to protect url for create quizzes also needed because they could manually type it in