### PR TITLE
Fixed Login Password Check

### DIFF
--- a/mentoris/templates/mentapp/login.html
+++ b/mentoris/templates/mentapp/login.html
@@ -117,8 +117,6 @@
                                 event.preventDefault();
                                 event.stopPropagation();
                             }
-
-                            form.classList.add("was-validated");
                         },
                         false
                     );


### PR DESCRIPTION
The Login page doesn't include a green check if the password is incorrect. 

I tried to keep the green check if the password was valid but there's a lag between fetching the information from the database and the frontend that prevents it from displaying before redirecting to the profile page. 